### PR TITLE
Update pathmap version and batch ga update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <properties>
     <javaVersion>1.8</javaVersion>
-    <pathmap.version>1.5-SNAPSHOT</pathmap.version>
+    <pathmap.version>1.6-SNAPSHOT</pathmap.version>
     <logback.version>1.1.7</logback.version>
   </properties>
 

--- a/src/main/java/org/commonjava/migrate/pathmap/MigrateOptions.java
+++ b/src/main/java/org/commonjava/migrate/pathmap/MigrateOptions.java
@@ -35,16 +35,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.commonjava.migrate.pathmap.Util.CMD_MIGRATE;
-import static org.commonjava.migrate.pathmap.Util.CMD_SCAN;
-import static org.commonjava.migrate.pathmap.Util.DEFAULT_BASE_DIR;
-import static org.commonjava.migrate.pathmap.Util.DEFAULT_BATCH_SIZE;
-import static org.commonjava.migrate.pathmap.Util.DEFAULT_WORK_DIR;
-import static org.commonjava.migrate.pathmap.Util.PROCESSED_FILES_DIR;
-import static org.commonjava.migrate.pathmap.Util.STATUS_FILE;
-import static org.commonjava.migrate.pathmap.Util.TODO_FILES_DIR;
-import static org.commonjava.migrate.pathmap.Util.printInfo;
-import static org.commonjava.migrate.pathmap.Util.newLine;
+import static org.commonjava.migrate.pathmap.Util.*;
 import static org.commonjava.storage.pathmapped.pathdb.datastax.util.CassandraPathDBUtils.PROP_CASSANDRA_HOST;
 import static org.commonjava.storage.pathmapped.pathdb.datastax.util.CassandraPathDBUtils.PROP_CASSANDRA_KEYSPACE;
 import static org.commonjava.storage.pathmapped.pathdb.datastax.util.CassandraPathDBUtils.PROP_CASSANDRA_PASS;
@@ -499,7 +490,7 @@ public class MigrateOptions
             boolean isIndexEnabled = Boolean.parseBoolean( this.getIndexEnable() );
             CassandraMigrator.GACacheOptions cacheOptions =
                     new CassandraMigrator.GACacheOptions( isIndexEnabled, this.getIndexGAStorePattern(),
-                                                          this.getIndyCacheTable() );
+                                                          this.getIndyCacheTable(), Paths.get( getWorkDir(), GA_CACHE_DUMP ).toFile() );
             migrator = CassandraMigrator.getMigrator( cassandraProps, getBaseDir(), isDedupe(), getDedupeAlgorithm(), cacheOptions );
         }
     }

--- a/src/main/java/org/commonjava/migrate/pathmap/Util.java
+++ b/src/main/java/org/commonjava/migrate/pathmap/Util.java
@@ -46,6 +46,8 @@ public class Util
 
     static final String STATUS_FILE = "scan_final";
 
+    static final String GA_CACHE_DUMP = "ga_cache_dump";
+
     static final String PROGRESS_FILE = "migrate_progress";
 
     static final String CMD_SCAN = "scan";


### PR DESCRIPTION
The total number of ga entry is small. We can hold them and insert all at the end of migration. This will reduce many dup insertions and mitigate the impact to migraiont time. 
SELECT count(*) from ga; => 8912 (from indy-perf, almost same to prod)